### PR TITLE
fix(progress-bar): progress animation fix

### DIFF
--- a/src/components/PercentageDisplay.js
+++ b/src/components/PercentageDisplay.js
@@ -17,7 +17,7 @@ const Container = styled.div`
 const ProgressBar = styled.div`
   @keyframes bar-animation {
     0% { width: 0 }
-    100% { width: ${props => props.width}% }
+    100% { width: '${props => props.width}%' }
   };
 
   border-radius: 5px;


### PR DESCRIPTION
looks like styled components wants the percentage wrapped in a string 🤷‍♀️ 

i found an example in their docs where they're wrapping a percentage for width: 
https://www.styled-components.com/docs/tooling

^^
> var Simple = _styledComponents2.default.div(['width: 100%;'])